### PR TITLE
updated base api url

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -7,7 +7,7 @@ var qs       = require('querystring');
 
 module.exports = function client(opts) {
   var opts = defaults(opts, {
-    endpoint: 'https://resumatorapi.com/v1'
+    endpoint: 'https://api.resumatorapi.com/v1'
   });
 
   if (!opts.apiKey) {


### PR DESCRIPTION
Jazz seems to have put Swagger in front of their API, which made this older endpoint invalid.